### PR TITLE
Workflow enforcing merging into main from develop branch only

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,0 +1,14 @@
+name: 'Check Branch'
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'main' && github.head_ref != 'develop'
+        run: |
+          echo "ERROR: You can only merge to main from develop."
+          exit 1


### PR DESCRIPTION
Will make this workflow a required check for merging into `main`.

Only `develop` branch is allowed to be merged into `main`.