### PR TITLE
OFAC notify

### DIFF
--- a/.github/workflows/ofac-notify.yml
+++ b/.github/workflows/ofac-notify.yml
@@ -1,10 +1,10 @@
-name: Notify on OFAC changes
+name: Notify on OFAC list changes
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - ofac-notify
+      - develop
     paths:
       - 'src/constants/sanctioned_addresses_ofac.json'
 


### PR DESCRIPTION
Create GH Action notification for OFAC addresses list.

The action is triggered on changes to `develop` branch and create a trello card and sends notification to slack.